### PR TITLE
Allow manual runs of GitHub workflow from web UI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,13 +5,13 @@ name: cmake_saver pytest
 
 on:
   push:
-    branches: [ master ]
+    branches: [master]
   pull_request:
-    branches: [ master ]
+    branches: [master]
+  workflow_dispatch:
 
 jobs:
   test:
-
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
@@ -20,20 +20,20 @@ jobs:
         python-version: ["2.7", "3.5", "3.6", "3.7", "3.8", "3.9", "3.10"]
 
     steps:
-    - uses: actions/checkout@v2
-    - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
-      with:
-        python-version: ${{ matrix.python-version }}
-    - name: Install dependencies
-      run: |
-        python -m pip install --upgrade pip
-        python -m pip install flake8 yapf pytest pytest-cov
-    - name: Format with yapf
-      run: yapf -d -r .
-    - name: Lint with flake8
-      run: flake8 . --count --max-line-length=127 --show-source --statistics
-    - name: Test with pytest
-      run: pytest --cov=. --cov-report=xml
-    - name: Print coverage report
-      run: coverage report
+      - uses: actions/checkout@v2
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install flake8 yapf pytest pytest-cov
+      - name: Format with yapf
+        run: yapf -d -r .
+      - name: Lint with flake8
+        run: flake8 . --count --max-line-length=127 --show-source --statistics
+      - name: Test with pytest
+        run: pytest --cov=. --cov-report=xml
+      - name: Print coverage report
+        run: coverage report


### PR DESCRIPTION
Based on [this documentation](https://docs.github.com/en/actions/managing-workflow-runs/manually-running-a-workflow#configuring-a-workflow-to-run-manually), this probably needs to be in the default branch?

> To run a workflow manually, the workflow must be configured to run on the `workflow_dispatch` event. To trigger the `workflow_dispatch` event, your workflow must be in the default branch.